### PR TITLE
Remove unused variables

### DIFF
--- a/code/extensions/MetadataExtension.php
+++ b/code/extensions/MetadataExtension.php
@@ -323,9 +323,6 @@ class MetadataExtension extends DataExtension
             return;
         }
         
-        $p = $this->owner->Parent();
-        $d = $this->owner->getParent();
-        
         if (!$allSchemas = DataObject::get('MetadataSchema')) {
             return;
         }


### PR DESCRIPTION
These variables were never used in the function and were causing us problems when using dataobjects as pages where there's no parent.